### PR TITLE
Patchwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,7 @@ LARAVEL PATCHER
 
 #### Requirements:
 * PHP : 8.\*
-* Laravel: 9.\* 
-
-##### Background : 
-Once upon a time, our team do a stupid thing that affect our production database. 
-It was happens many times, and we are usually go tinkering or direct edit on a 
-database to fix those problems.
-Then, our team leader [Rifki Alhuraibi](https://github.com/veelasky/) comes up with
-the idea about the package that handle history change of our patch activity (like the 
-one in database migration), so we made this package. 
-Also, we commonly need to bulk insert data to our application, this package also help
-us in those activity.
+* Laravel: 9.\*
 
 ### INSTALLATION
 do either of this methods below.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ composer require dentro/laravel-patcher
 ```json
 {
   "require": {
-    ...
     "dentro/laravel-patcher": "^1.0"
   }
 }
@@ -43,16 +42,10 @@ Those file will be like:
 ```php
 <?php
 
-use Jalameta\Patcher\Patch;
+use Dentro\Patcher\Patch;
 
 class WhatDoYouWantToPatch extends Patch
 {
-    /**
-     * Run patch script.
-     *
-     * @return void
-     * @throws \Exception
-     */
     public function patch()
     {
         // 
@@ -116,3 +109,37 @@ Patching: 2020_10_09_124616_add_attachment_beep
 Patched:  2020_10_09_124616_add_attachment_beep (0.06 seconds)
 ```
 
+#### SKIPPING THE PATCH
+You might need to skip single patch when run ```php artisan patcher:run```. 
+Due to patch is unnecessary or patch is not eligible to run in your environment. 
+Here you can add the ```eligible``` method to your patch class to evaluate the condition 
+before running the ```patch``` method.   
+
+```php
+<?php
+
+use Dentro\Patcher\Patch;
+use App\Models\User;
+
+class WhatDoYouWantToPatch extends Patch
+{
+    public function eligible(): bool
+    {
+        return User::query()->where('id', 331)->exists();
+    }
+    
+    public function patch()
+    {
+        $user = User::query()->find(331);
+        // do something with user.
+    }
+}
+```
+then the output of ```php artisan patcher:run``` will be:
+```shell script
+➜ php artisan patcher:run
+Patching: 2020_09_29_190531_fix_double_sections
+Skipped:  2020_09_29_190531_fix_double_sections is not eligible to run in current condition.
+Patching: 2020_10_09_124616_add_attachment_beep
+Patched:  2020_10_09_124616_add_attachment_beep (0.06 seconds)
+```

--- a/src/Console/PatchCommand.php
+++ b/src/Console/PatchCommand.php
@@ -3,9 +3,6 @@
 namespace Dentro\Patcher\Console;
 
 use Illuminate\Console\ConfirmableTrait;
-use Illuminate\Database\SQLiteConnection;
-use Illuminate\Database\Events\SchemaLoaded;
-use Illuminate\Database\SqlServerConnection;
 use Illuminate\Database\Console\Migrations\MigrateCommand;
 
 class PatchCommand extends MigrateCommand

--- a/src/Patch.php
+++ b/src/Patch.php
@@ -38,14 +38,6 @@ abstract class Patch extends Migration
     public $withinTransaction = false;
 
     /**
-     * Patch constructor.
-     */
-    public function __construct()
-    {
-        $this->logger = app('log')->driver(PatcherServiceProvider::$LOG_CHANNEL);
-    }
-
-    /**
      * Run patch script.
      *
      * @return void
@@ -76,5 +68,15 @@ abstract class Patch extends Migration
         $this->container = $container;
 
         return $this;
+    }
+
+    /**
+     * Set Logger instance.
+     *
+     * @param \Illuminate\Log\Logger $logger
+     */
+    public function setLogger(Logger $logger): void
+    {
+        $this->logger = $logger;
     }
 }

--- a/src/Patch.php
+++ b/src/Patch.php
@@ -30,6 +30,13 @@ abstract class Patch extends Migration
     protected $logger;
 
     /**
+     * Enables, if supported, wrapping the migration within a transaction.
+     *
+     * @var bool
+     */
+    public $withinTransaction = false;
+
+    /**
      * Patch constructor.
      */
     public function __construct()

--- a/src/Patch.php
+++ b/src/Patch.php
@@ -5,6 +5,7 @@ namespace Dentro\Patcher;
 use Illuminate\Console\Command;
 use Illuminate\Container\Container;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Log\Logger;
 
 abstract class Patch extends Migration
 {
@@ -13,24 +14,24 @@ abstract class Patch extends Migration
      *
      * @var \Illuminate\Console\Command
      */
-    protected $command;
+    protected Command $command;
 
     /**
      * The container instance.
      *
      * @var \Illuminate\Container\Container
      */
-    protected $container;
+    protected Container $container;
 
     /**
      * Logger.
      *
      * @var \Illuminate\Log\Logger
      */
-    protected $logger;
+    protected Logger $logger;
 
     /**
-     * Enables, if supported, wrapping the migration within a transaction.
+     * Enables, if supported, wrapping the patch within a transaction.
      *
      * @var bool
      */

--- a/src/Patcher.php
+++ b/src/Patcher.php
@@ -63,28 +63,28 @@ class Patcher extends Migrator
 
         $startTime = microtime(true);
 
-        if (method_exists($migration, 'eligible') && $migration->eligible())
-        {
+        if ($this->isEligible()) {
             $this->runPatch($migration);
+
+            $runTime = round(microtime(true) - $startTime, 2);
+
+            $this->repository->log($name, $batch);
+
+            $this->note("<info>Patched:</info>  {$name} ({$runTime} seconds).");
+        } else {
+            $this->note("<comment>Skipped:</comment> {$name} is not eligible to run in current condition.");
         }
-
-        $runTime = round(microtime(true) - $startTime, 2);
-
-        $this->repository->log($name, $batch);
-
-        $this->note("<info>Patched:</info>  {$name} ({$runTime} seconds)");
     }
 
     /**
      * Determine if patcher should run.
      *
-     * @param \Illuminate\Database\Migrations\Migration $migration
      * @return bool
      */
-    public function isEligible(Migration $migration): bool
+    public function isEligible(): bool
     {
-        if (method_exists($migration, 'eligible')) {
-            return $migration->eligible();
+        if (method_exists($this, 'eligible')) {
+            return $this->eligible();
         }
 
         return true;


### PR DESCRIPTION
- [x] add `eligible()` method to check whether the patch should run, closes #1 
- [x] disable patch run within transaction, because it is different behavior than migration, patch should not be enclosed within transaction, let the developer decide, this package usually handle a lot of data  and some can be lost in huge amount of transactions.